### PR TITLE
fix: aタグの装飾を抑制しないよう修正

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -95,11 +95,6 @@ body {
     rgb(var(--background-start-rgb));
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;


### PR DESCRIPTION
@t0m0120 
クリックできる箇所がわかりにくいと思ったのでaタグのスタイルを修正してみました！

**修正前**
![image](https://github.com/t0m0120/IshikawaTakidashiMap/assets/13270461/d6e8c7db-87bc-4789-9eb0-4a62979fa921)

**修正後**
![image](https://github.com/t0m0120/IshikawaTakidashiMap/assets/13270461/84c0aa61-5499-463a-842a-0ff7c133e6d7)

よろしければマージください。
よろしくお願いします。